### PR TITLE
Update sh_atmos.lua

### DIFF
--- a/lua/atmos/shared/sh_atmos.lua
+++ b/lua/atmos/shared/sh_atmos.lua
@@ -117,7 +117,7 @@ function AtmosClass:GetWeatherByID(id)
 
     if !id then return end
 
-    local index = self.WeatherIDs[id]
+    local index = self.WeathersIDs[id]
 
     if !index then return end
 


### PR DESCRIPTION
Fixed typo "self.WeatherIDs" to "self.WeathersIDs" in AtmosClass:GetWeatherByID